### PR TITLE
fixed rounding positive deltaX/Y

### DIFF
--- a/config snippet.lua
+++ b/config snippet.lua
@@ -159,7 +159,7 @@ function mouseScrollTimerFunction()
             end
 
             deltaX = deltaXRounding(deltaX)
-            deltaY = deltaXRounding(deltaY)
+            deltaY = deltaYRounding(deltaY)
 
             -- reverse Y scroll if 'reverseVerticalScrollDirection' set to true
             if reverseVerticalScrollDirection then

--- a/config snippet.lua
+++ b/config snippet.lua
@@ -147,9 +147,19 @@ function mouseScrollTimerFunction()
                 deltaY = deltaY * deltaY * deltaYDirMod
             end
 
-            -- math.floor - scroll event accepts only integers
-            deltaX = math.floor(deltaX)
-            deltaY = math.floor(deltaY)
+            -- math.ceil / math.floor - scroll event accepts only integers
+            deltaXRounding = math.ceil
+            deltaYRounding = math.ceil
+
+            if deltaX < 0 then
+                deltaXRounding = math.floor
+            end
+            if deltaY < 0 then
+                deltaYRounding = math.floor
+            end
+
+            deltaX = deltaXRounding(deltaX)
+            deltaY = deltaXRounding(deltaY)
 
             -- reverse Y scroll if 'reverseVerticalScrollDirection' set to true
             if reverseVerticalScrollDirection then


### PR DESCRIPTION
Now uses `math.ceil` for positive `deltaX`/`Y`.

## Explanation

For small enough `scrollSpeedMultiplier` (I used `0.01`), `deltaX * scrollSpeedMultiplier` may end up having an absolute value less than 1. We have two cases:

1. `-1 < deltaX * scrollSpeedMultiplier < 0`: Applying `math.floor` gives us the desired result. It rounds `deltaX` to -1 and we begin to scroll slowly.
2. `0 < deltaX * scrollSpeedMultiplier < 1`: Applying `math.floor` rounds `deltaX` to zero. We cannot scroll until we move the mouse farther such that `deltaX * scrollSpeedMultiplier > 1`.

I suggest using `math.ceil` for rounding in the positive case. This would make the rounding more "symmetric" and so scrolling will feel equally nice in both directions.

Without this fix, there is an extra "deadzone" to the right and below the circle. I encountered this with `scrollSpeedMultiplier = 0.01`.