### PR TITLE
Allow scrolling by small amounts

### DIFF
--- a/config snippet.lua
+++ b/config snippet.lua
@@ -8,6 +8,8 @@ local mouseScrollButtonId = 2
 
 -- scroll speed and direction config
 local scrollSpeedMultiplier = 0.15
+local scrollSpeedHorizontalMultiplier = scrollSpeedMultiplier
+local scrollSpeedVerticalMultiplier = scrollSpeedMultiplier
 local scrollSpeedSquareAcceleration = false
 local reverseVerticalScrollDirection = false
 local mouseScrollTimerDelay = 0.01
@@ -132,9 +134,9 @@ function mouseScrollTimerFunction()
             deltaX = deltaX - signX * math.min(xDiff, mouseScrollCircleRad)
             deltaY = deltaY - signY * math.min(yDiff, mouseScrollCircleRad)
 
-            -- use 'scrollSpeedMultiplier'
-            deltaX = deltaX * scrollSpeedMultiplier
-            deltaY = deltaY * scrollSpeedMultiplier
+            -- use 'scrollSpeedHorizontalMultiplier' and 'scrollSpeedVerticalMultiplier'
+            deltaX = deltaX * scrollSpeedHorizontalMultiplier
+            deltaY = deltaY * scrollSpeedVerticalMultiplier
 
             -- square for better scroll acceleration
             if scrollSpeedSquareAcceleration then


### PR DESCRIPTION
Because the scroll timer delay is very small, the current minimal scroll of 1 (fractions being rounded up) per timer period makes it difficult to scroll by small amounts. 

Fractional scrolling allows scrolling by very small amounts. It is implemented by storing fractions in a variable and only firing a scroll when it accumulates to more than 1. This feature can be turned off in the config, and will fall back to the previous behavior.

As a aside, horizontal and vertical scroll factors can now be set independently to account for perception difference between horizontal and vertical content by the human eye.